### PR TITLE
nullチェック追加

### DIFF
--- a/kumaS Asset/Sclipts/FaceTrack/ApplyToVRM.cs
+++ b/kumaS Asset/Sclipts/FaceTrack/ApplyToVRM.cs
@@ -33,8 +33,15 @@ namespace kumaS.FaceTrack
 
             transform.position = tracking.Position;
             transform.rotation = tracking.Rotation;
-            left_eye.localEulerAngles = tracking.LeftEyeRotation;
-            right_eye.localEulerAngles = tracking.RightEyeRotation;
+
+            if(left_eye)
+            {
+                left_eye.localEulerAngles = tracking.LeftEyeRotation;
+            }
+            if(right_eye)
+            {
+                right_eye.localEulerAngles = tracking.RightEyeRotation;
+            }
         }
     }
 }


### PR DESCRIPTION
FBXから変換されたVRMなどでは、本来のVRMで想定されていないような目の構造になっている場合もあるため、ApplyToVRMに目のTransformを追加しなくても動作するように変更を行いました